### PR TITLE
Add note for change pass on api v2

### DIFF
--- a/templates/sdk_auth_api.ejs
+++ b/templates/sdk_auth_api.ejs
@@ -165,10 +165,16 @@ Content-Type: 'application/json'
 <form id='ro-form'>{
   "client_id":   "<span class="client_client_id"></span>", // <span class="client_name"></span>
   "email":       "<input type="text" id="chpwd-email" required>",
-  "password":    "<input type="password" id="chpwd-password">", // <span>OPTIONAL: The new password</span>
+  "password":    "<input type="password" id="chpwd-password">", // <span>OPTIONAL: The new password (see note below)</span>
   "connection":  "<select id="chpwd-connection" class="db_connection-selector"></select>",
 }
 </form></code></pre>
+
+<div class="alert-info alert">
+
+  <strong>Heads up!</strong> If you are using Lock version 9 and above, do not set the password field! If you do, you will receive a *password is not allowed* error. You can only set the password if you are using Lock version 8. <a href="<%= docsDomain %>/connections/database/password-change" target="_new">Click here for more details.</a>
+
+</div>
 
 <button class='btn btn-primary btn-tryme'
         data-result='chpwd-result'


### PR DESCRIPTION
Customer support reported that some users set the password field, while using API version 2, which results in errors.

A note has been added to inform the users of this and redirect them to the change password documentation.

Document to be reviewed by support and copyeditor before merge.

Should also be probably merged together with: https://github.com/auth0/docs/pull/1261