### PR TITLE
Show a combo box with the tenant users in the impersonation parameter Fixes auth0/auth0-server#2209

### DIFF
--- a/js/sdk.AuthApiExecutors.js
+++ b/js/sdk.AuthApiExecutors.js
@@ -70,7 +70,7 @@ define(function(require) {
       var user_id = $('#impersonate-user_id option:selected').val();
       var data = {
         protocol: $('#impersonate-protocol option:selected').val(),
-        impersonator_id: $('#impersonate-impersonator_id').text(),
+        impersonator_id: $('#impersonate-impersonator_id option:selected').val(),
         client_id: $('#impersonate-client_id option:selected').val(),
         additionalParameters: additional_parameters
       };

--- a/templates/sdk_auth_api.ejs
+++ b/templates/sdk_auth_api.ejs
@@ -643,7 +643,7 @@ Content-Type:   'application/json'
 Authorization:  'Bearer <span class="global_client_access_token"></span>'
 <form id='impersonate-form'>{
   protocol:             "<select id="impersonate-protocol" class="protocol-selector"></select>",
-  impersonator_id:      "<span id="impersonate-impersonator_id"><%= user.id %></span>", // <%= user.name || user.email %>
+  impersonator_id:      "<span id="impersonate-impersonator_id"><select id="impersonate-user_id" class="user-selector"></select></span>",
   client_id:            "<select id="impersonate-client_id" name="client-list-without-global" class="with-id"></select>",
   additionalParameters: <textarea id="impersonate-additional_parameters" rows="3" style="width:325px;">"response_type": "code",&#13;&#10;"state": ""</textarea>
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1621154/15620523/1ab1a498-2431-11e6-9c28-b9cf43d47429.png)

The decoded bewit generated is:

``` js
{
"tenant":"login0",
"globalClientID":"aCbTAJNi5HbsjPJtRpSP6BIoLPOrSj2Cgg",
"clientID":"aCbTAJNi5HbsjPJtRpSP6BIoLPOrSj2C",
"impersonator_id":"samlp|john@fabrikam.com",
"additionalParameters":{"response_type":"code","state":""},
"protocol":"oauth2"
}
```
