### PR TITLE
Add /v2/logout Fixes auth0/crew-1#227

### DIFF
--- a/js/sdk.AuthApiExecutors.js
+++ b/js/sdk.AuthApiExecutors.js
@@ -398,6 +398,16 @@ define(function(require) {
       window.open(url, '_new');
     };
 
+    this['v2-logout'] = function() {
+
+      var returnTo = $('#v2-logout-returnTo').val();
+      var client_id = $('#v2-logout-client_id').val();
+
+      var url = urljoin(client.namespace, '/v2/logout', '?returnTo=' + returnTo, '&client_id=' + client_id);
+
+      window.open(url, '_new');
+    };
+
     this['samlp'] = function() {
 
       var connection = $('#samlp-connection option:selected').val();

--- a/templates/sdk_auth_api.ejs
+++ b/templates/sdk_auth_api.ejs
@@ -845,7 +845,8 @@ Content-Type: 'application/json'
 <div class="accordion">
 
 <!-- GET /logout -->
-  <div class="markdown" data-verb="GET" data-path="/logout" data-description="Trigger the logout flow">
+  <div class="markdown" data-verb="GET" data-path="/logout" data-description="Trigger the logout flow (deprecated)">
+  <b>Please use `/v2/logout` instead.</b><br/>
  Logout the user from the identity provider. If you specify a `returnTo` parameter, we will redirect to the URL specified after the logout. This URL should included in any of the `Allowed Logout URLs` lists. There is a list at the application level (you need to use the `client_id` parameter to select the desired application's Allowed Logout URLs list) and a list at the Account level. Read more about [here](<%= docsDomain %>/logout).
 
 <pre><code><span class='http-verb'>GET</span> <span class="client_namespace"></span>logout?
@@ -856,6 +857,22 @@ returnTo=<input type="text" id="logout-returnTo" placeholder="return url"></inpu
 <button class='btn btn-primary btn-tryme'
         data-result='logout-result'
         data-runner='logout'>
+   Try me!
+</button>
+  </div>
+
+<!-- GET /v2/logout -->
+  <div class="markdown" data-verb="GET" data-path="/v2/logout" data-description="Trigger the logout flow (recommended)">
+ Logout the user from the identity provider. If you specify a `returnTo` parameter, we will redirect to the URL specified after the logout. This URL should included in any of the `Allowed Logout URLs` lists. There is a list at the application level (you need to use the `client_id` parameter to select the desired application's Allowed Logout URLs list) and a list at the Account level. Read more about [here](<%= docsDomain %>/logout).
+
+<pre><code><span class='http-verb'>GET</span> <span class="client_namespace"></span>v2/logout?
+returnTo=<input type="text" id="v2-logout-returnTo" placeholder="return url"></input>
+&client_id=<input type="text" id="v2-logout-client_id" placeholder="client id"></input>
+</code></pre>
+
+<button class='btn btn-primary btn-tryme'
+        data-result='v2-logout-result'
+        data-runner='v2-logout'>
    Try me!
 </button>
   </div>


### PR DESCRIPTION
Add `/v2/logout` endpoint and a recommendation on the `/logout` endpoint to use the `v2` one.

![image](https://cloud.githubusercontent.com/assets/1621154/17027988/7004f5c2-4f3c-11e6-96b4-4efeea731de8.png)
![image](https://cloud.githubusercontent.com/assets/1621154/17028001/7637b678-4f3c-11e6-8e4c-596779189c51.png)
