### PR TITLE
Show a combo box with the tenant users in the impersonator_id parameter

### DIFF
--- a/js/sdk.AuthApiExecutors.js
+++ b/js/sdk.AuthApiExecutors.js
@@ -70,7 +70,7 @@ define(function(require) {
       var user_id = $('#impersonate-user_id option:selected').val();
       var data = {
         protocol: $('#impersonate-protocol option:selected').val(),
-        impersonator_id: $('#impersonate-impersonator_id').text(),
+        impersonator_id: $('#impersonate-impersonator_id option:selected').val(),
         client_id: $('#impersonate-client_id option:selected').val(),
         additionalParameters: additional_parameters
       };

--- a/templates/sdk_auth_api.ejs
+++ b/templates/sdk_auth_api.ejs
@@ -789,12 +789,14 @@ For example:
 <!-- POST /users/{user_id}/impersonate -->
   <div class="markdown" data-verb="POST" data-path="/users/{user_id}/impersonate" data-description="Obtain an impersonation URL to login as another user">
 
+The user list used in the POST url and `impersonator_id` is just an example, you can set the `user_id` from any user in the <a target="_new" href="https://<%= appDomain %>/#/users">Dashboard User section</a>
+
 <pre><code class="nohighlight"><span class='http-verb'>POST</span> <span class="client_namespace"></span>users/<select id="impersonate-user_id" class="user-selector"></select>/impersonate
 Content-Type:   'application/json'
 Authorization:  'Bearer <span class="global_client_access_token"></span>'
 <form id='impersonate-form'>{
   protocol:             "<select id="impersonate-protocol" class="protocol-selector"></select>",
-  impersonator_id:      "<span id="impersonate-impersonator_id"><%= user.id %></span>", // <%= user.name || user.email %>
+  impersonator_id:      "<span id="impersonate-impersonator_id"><select id="impersonate-user_id" class="user-selector"></select></span>",
   client_id:            "<select id="impersonate-client_id" name="client-list-without-global" class="with-id"></select>",
   additionalParameters: <textarea id="impersonate-additional_parameters" rows="3" style="width:325px;">"response_type": "code",&#13;&#10;"state": ""</textarea>
 }


### PR DESCRIPTION
Previously,  the impersonator was always the current logged in user, which is the dashboard admin visiting the Auhtentication API docs. For the tenants out of US region, the dashboard admins are not in their database (EU, AU), they belong to the manage/Dashboard user database (in US). So they could not use the Api Explorer to generate impersonation links.

With this change they can choose a user that exists in their database (wherever it is, EU, AU or US).

This is an evolution of: https://github.com/auth0/api-explorer/pull/113
This only adds the message explaining the concept of that list of users.

![screen shot 2016-11-23 at 8 09 45 pm](https://cloud.githubusercontent.com/assets/1424663/20575369/4a4c87f2-b1b9-11e6-8813-4a0fb2fdf2dc.png)

It uses a environment variable for the dashboard domain coming from auth0-docs and set in auth0-configuration for all environments (Public and Private cloud).
https://github.com/auth0/auth0-docs/pull/1239


Fixes: https://github.com/auth0/auth0-server/issues/2209